### PR TITLE
Use a fork of the buildah task with fixes

### DIFF
--- a/.tekton/fedora-flatpak-ghex-pull-request.yaml
+++ b/.tekton/fedora-flatpak-ghex-pull-request.yaml
@@ -225,17 +225,26 @@ spec:
         value: $(tasks.clone-repository.results.commit)
       - name: BUILD_ARGS_FILE
         value: $(params.build-args-file)
+      - name: BUILDAH_EXTRA_ARGS
+        value: >-
+          --skip-unused-stages=false
+          --device=/dev/null:/contents/dev/null
+          --device=/dev/random:/contents/dev/random
+          --device=/dev/urandom:/contents/dev/urandom
+          --device=/dev/zero:/contents/dev/zero
       runAfter:
       - prefetch-dependencies
       taskRef:
         params:
         - name: name
           value: buildah
-        - name: bundle
-          value: quay.io/redhat-appstudio-tekton-catalog/task-buildah:0.1@sha256:7e5f19d3aa233b9becf90d1ca01697486dc1acb1f1d6d2a0b8d1a1cc07c66249
-        - name: kind
-          value: task
-        resolver: bundles
+        - name: url
+          value: https://github.com/owtaylor/build-definitions.git
+        - name: revision
+          value: flatpak
+        - name: pathInRepo
+          value: task/buildah/0.1/buildah.yaml
+        resolver: git
       when:
       - input: $(tasks.init.results.build)
         operator: in

--- a/.tekton/fedora-flatpak-ghex-push.yaml
+++ b/.tekton/fedora-flatpak-ghex-push.yaml
@@ -222,17 +222,26 @@ spec:
         value: $(tasks.clone-repository.results.commit)
       - name: BUILD_ARGS_FILE
         value: $(params.build-args-file)
+      - name: BUILDAH_EXTRA_ARGS
+        value: >-
+          --skip-unused-stages=false
+          --device=/dev/null:/contents/dev/null
+          --device=/dev/random:/contents/dev/random
+          --device=/dev/urandom:/contents/dev/urandom
+          --device=/dev/zero:/contents/dev/zero
       runAfter:
       - prefetch-dependencies
       taskRef:
         params:
         - name: name
           value: buildah
-        - name: bundle
-          value: quay.io/redhat-appstudio-tekton-catalog/task-buildah:0.1@sha256:7e5f19d3aa233b9becf90d1ca01697486dc1acb1f1d6d2a0b8d1a1cc07c66249
-        - name: kind
-          value: task
-        resolver: bundles
+        - name: url
+          value: https://github.com/owtaylor/build-definitions.git
+        - name: revision
+          value: flatpak
+        - name: pathInRepo
+          value: task/buildah/0.1/buildah.yaml
+        resolver: git
       when:
       - input: $(tasks.init.results.build)
         operator: in

--- a/Containerfile
+++ b/Containerfile
@@ -8,7 +8,7 @@ COPY container.yaml /tmp
 RUN --mount=type=bind,rw,src=/,dst=/contents,from=install \
     --mount=type=bind,rw,z,src=export,dst=/export \
     flatpak-module container-export \
-        --containerspec=/tmp/container-archive.yaml \
+        --containerspec=/tmp/container.yaml \
         --resultdir=/export
 
 FROM oci-archive:export/out.ociarchive

--- a/Containerfile
+++ b/Containerfile
@@ -5,7 +5,7 @@ RUN dnf5 -y install ghex
 FROM quay.io/redhat-user-workloads/otaylor-tenant/flatpak-module-tools/flatpak-module-tools@sha256:d7d59011e1c0730e420655aea712dacb73e88898ea89cfe004f54b7be0fe44ae as export
 
 COPY container.yaml /tmp
-RUN --mount=type=bind,src=/,dst=/contents,from=install \
+RUN --mount=type=bind,rw,src=/,dst=/contents,from=install \
     --mount=type=bind,rw,z,src=export,dst=/export \
     flatpak-module container-export \
         --containerspec=/tmp/container-archive.yaml \


### PR DESCRIPTION
The forked buildah build task:
 - Allows us to set BUILDAH_EXTRA_ARGS as needed for Flatpaks
 - Uses a newer version of buildah
 - Uses a context of . if possible